### PR TITLE
Improve install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,25 @@ For step-by-step setup instructions, open [docs/instructions.html](docs/instruct
 
 ## Development
 
+Install dependencies with:
 
-Run `npm test` once to install dependencies and verify tests.
-Then run `npm start` to launch the Express server.
+```bash
+npm install --legacy-peer-deps
+```
 
-Run `npm start` to launch the Express server after installing dependencies.
+Run the tests once:
+
+```bash
+npm test
+```
+
+Start the Express server:
+
+```bash
+npm start
+```
+
+`express-graphql` is currently used for the GraphQL endpoint. The package is deprecated and may be replaced by `graphql-http` in a future update.
 
 
 ### Resetting the remote repo

--- a/docs/instructions.html
+++ b/docs/instructions.html
@@ -15,10 +15,10 @@
   <section>
     <h2>Install</h2>
 
-    <p>Run <code>npm test</code> once to install dependencies and execute the test suite.</p>
-    <p>If you prefer manual installation use <code>npm install --legacy-peer-deps</code>.</p>
+      <p>Run <code>npm install --legacy-peer-deps</code> to install dependencies.</p>
+      <p>You can also execute <code>npm test</code> once to install dependencies and run the test suite.</p>
 
-    <p>Run <code>npm install</code> to install dependencies.</p>
+      <p><em>express-graphql is deprecated and may be replaced by <code>graphql-http</code> in a future update.</em></p>
 
   </section>
   <section>


### PR DESCRIPTION
## Summary
- update README instructions
- show `npm install --legacy-peer-deps` usage in docs
- note the deprecation of express-graphql

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686efed7cf0c8321accba536a4c7c9ed