### PR TITLE
Add admin dashboard instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 See [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) for the complete project plan.
 For step-by-step setup instructions, open [docs/instructions.html](docs/instructions.html) in your browser.
+The admin dashboard is launched with `npm run admin` as described in the instructions file.
 
 ## Development
 

--- a/docs/instructions.html
+++ b/docs/instructions.html
@@ -29,6 +29,7 @@
   <section>
     <h2>Admin dashboard</h2>
     <p>Navigate to <code>/admin.html</code> to enter your API keys. This sets up environment variables so the server can communicate with OnlyFans and OpenAI.</p>
+    <p>Start the dashboard with <code>npm run admin</code>. This launches a server that serves <code>http://localhost:4000/admin.html</code>.</p>
   </section>
   <section>
     <h2>Features</h2>


### PR DESCRIPTION
## Summary
- document how to start the admin dashboard in `docs/instructions.html`
- reference this procedure from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686efeed8b308321b4969fda0a25e8df