### PR TITLE
Add CI pipeline steps per project plan

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,9 +3,21 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      OF_API_TOKEN: ${{ secrets.OF_API_TOKEN_STAGING }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Test
+        run: npm test
+      - name: Build
+        run: npm run build --if-present
+      - name: Build Docker image
+        run: docker build -t of-manager:${{ github.sha }} .


### PR DESCRIPTION
## Summary
- run install, lint, test and build in CI
- build Docker image tagged with the commit SHA
- expose OF_API_TOKEN_STAGING and OPENAI_KEY secrets to jobs

## Testing
- `npm test`
- `npm run lint --if-present`
- `npm run build --if-present`
- `docker build -t of-manager:test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686efef0e0a483218283d052265ba45d